### PR TITLE
Require generated parser *after* the Owners module is defined

### DIFF
--- a/lib/owners.rb
+++ b/lib/owners.rb
@@ -1,4 +1,3 @@
-require "owners/parser"
 require "owners/version"
 
 module Owners
@@ -48,3 +47,5 @@ module Owners
     end
   end
 end
+
+require "owners/parser"


### PR DESCRIPTION
Otherwise requiring the gem results in the following error:

$ ruby -Ilib -rowners -e'p 1'
OWNERS/lib/owners/lexer.rb:8:in `<top (required)>': uninitialized constant Owners (NameError)

I am not sure why the build did not catch this; I found out updating one
of our application to the use the upstream version instead of our
internal fork.