### PR TITLE
Fixes bug with comments

### DIFF
--- a/lib/owners/lexer.l
+++ b/lib/owners/lexer.l
@@ -5,7 +5,7 @@ macro
   TEAMNAME          @[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-]+
   USERNAME          @[a-zA-Z0-9\-]+
   GLOB              [a-zA-Z0-9_\-\*\?\.]+
-  COMMENT           \# [^\"\n\"]*
+  COMMENT           \#\s[^\"\n\"]*
   NEWLINE           \n
   WHITESPACE        \s
 rule

--- a/lib/owners/lexer.rb
+++ b/lib/owners/lexer.rb
@@ -72,7 +72,7 @@ class Owners::Parser < Racc::Parser
       when (text = @ss.scan(/[a-zA-Z0-9_\-\*\?\.]+/))
          action { [:GLOB, text] }
 
-      when (text = @ss.scan(/\#/))
+      when (text = @ss.scan(/\#\s[^\"\n\"]*/))
          action { [:COMMENT, text] }
 
       when (text = @ss.scan(/\n/))

--- a/test/owners_test.rb
+++ b/test/owners_test.rb
@@ -38,5 +38,13 @@ describe Owners do
     it "ignores comments and newlines" do
       assert_equal ["@owner"], Owners::File.new("# README\n\n\n@owner").for("README")
     end
+
+    it "ignores tokens after comment mark" do
+      assert_equal [], Owners::File.new("# @owner").for("README")
+    end
+
+    it "ignores comments containing special characters" do
+      assert_equal ["@owner"], Owners::File.new("# R,E;A.D'M/E:\n\n@owner").for("README")
+    end
   end
 end


### PR DESCRIPTION
I noticed an issue where OWNERS was failing to parse a comment in one of my OWNERS files of the form:

```
# <text>, <more text>
```

This illustrated itself in an exception during parsing.

At first, I suspected that there was an issue with the comments being tokenized incorrectly when they had commas.

However, a teammate pointed out that this is simply the wrong syntax for a space in racc, and comments probably weren't working at all.

Observe that the test:

```
it "ignores tokens after comment mark" do
  assert_equal [], Owners::File.new("# @owner").for("README")
end
```

Currently fails.

I switched the syntax over and added tests over the case that originally prompted the issue as well as the one that ensures comments are actually functional.

Please let me know if there's anything else I can do to assist in getting this merged.